### PR TITLE
Update variables.tf values and descriptions

### DIFF
--- a/modules/lambda-registrator/variables.tf
+++ b/modules/lambda-registrator/variables.tf
@@ -11,17 +11,15 @@ variable "consul_http_addr" {
 variable "consul_ca_cert_path" {
   description = "The Parameter Store path containing the Consul server CA certificate."
   type        = string
-  default     = ""
 }
 
 variable "consul_http_token_path" {
   description = "The Parameter Store path containing the Consul ACL token."
   type        = string
-  default     = ""
 }
 
 variable "node_name" {
-  description = "The Consul node that Lambdas will be registered to."
+  description = "The Consul node that Lambda functions will be registered to."
   type        = string
   default     = "lambdas"
 }
@@ -32,20 +30,20 @@ variable "enterprise" {
   default     = false
 }
 
-variable "partitions" {
-  description = "Specifies the partitions that Lambda registrator will manage [Consul Enterprise]."
+variable "admin_partitions" {
+  description = "Specifies the admin partitions that Lambda function registrator will manage [Consul Enterprise]."
   type        = list(string)
-  default     = []
+  default     = var.enterprise ? [] : null
 }
 
 variable "timeout" {
-  description = "The maximum number of seconds Lambda registrator can run before timing out."
+  description = "The maximum number of seconds Lambda function registrator can run before timing out."
   type        = number
   default     = 30
 }
 
 variable "reserved_concurrent_executions" {
-  description = "The amount of reserved concurrent executions for Lambda registrator."
+  description = "The amount of reserved concurrent executions for Lambda function registrator."
   type        = number
   default     = -1
 }
@@ -68,13 +66,11 @@ variable "sync_frequency_in_minutes" {
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs associated with Lambda registrator"
+  description = "List of subnet IDs associated with Lambda function registrator"
   type        = list(string)
-  default     = []
 }
 
 variable "security_group_ids" {
-  description = "List of security group IDs associated with Lambda registrator"
+  description = "List of security group IDs associated with Lambda function registrator"
   type        = list(string)
-  default     = []
 }


### PR DESCRIPTION
@erichaberkorn 

👋 

I'm proposing a few changes in this PR:

* Rename "Lambda registrator -> Lambda function registrator" since Lambda is the name of the service, but the registrator is registering specific Lambda functions.
* Renaming "partitions" variable -> "admin_partitions" - This is intended to add clarity as to the purpose of this variable.
  * Set a conditional expression that sets the default value to an empty list when `enterprise` is true, otherwise set it as a null value.
* Removing empty-default property values that are required by the consumer of the module.
 
 I'm not sure what our style guide is on the last point, but these empty values are causing trouble for me, as they are already technically set according to terraform. If I don't pass the property in the module, the value falls back to this empty declaration, which then fails after an apply. Here's an example where I have two modules: One with misssing properties as reported by the IDE, and one where the IDE understands all the values of this module are correctly set. In both cases, I need pass consul_*, but in both cases, the IDE reports that this is not a required property.

![image](https://user-images.githubusercontent.com/960210/172915896-a75ab457-9ccd-45c7-bee0-c01015d891bb.png)


In this circumstance, I *think* these values are required in every circumstance, and should be explicitly passed by the module consumer:

* security_group_ids
* subnet_ids
* consul_http_token_path
* consul_ca_cert_path

Please correct me if I'm wrong 😄 

 