### PR TITLE
Add consul-lambda-extension

### DIFF
--- a/consul-lambda-registrator/client/lambda.go
+++ b/consul-lambda-registrator/client/lambda.go
@@ -1,0 +1,211 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	fmtExtensionURL     = "http://%s/2020-01-01/extension"
+	headerExtensionName = "Lambda-Extension-Name"
+	headerExtensionID   = "Lambda-Extension-Identifier"
+)
+
+// Lambda is a client for interfacing with AWS Lambda APIs.
+type Lambda struct {
+	baseURL      string
+	httpClient   *http.Client
+	extensionID  string
+	lambdaClient *lambda.Client
+	pageSize     int
+}
+
+// RegisterResponse is the body of the response for /register
+type RegisterResponse struct {
+	FunctionName    string            `json:"functionName"`
+	FunctionVersion string            `json:"functionVersion"`
+	Handler         string            `json:"handler"`
+	Configuration   map[string]string `json:"configuration"`
+}
+
+// NextEventResponse is the response for /event/next
+type NextEventResponse struct {
+	EventType          EventType `json:"eventType"`
+	DeadlineMs         int64     `json:"deadlineMs"`
+	RequestID          string    `json:"requestId"`
+	InvokedFunctionArn string    `json:"invokedFunctionArn"`
+	Tracing            Tracing   `json:"tracing"`
+}
+
+// Tracing is part of the response for /event/next
+type Tracing struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// EventType represents the type of events received from /event/next
+type EventType string
+
+const (
+	Shutdown EventType = "SHUTDOWN"
+)
+
+// NewLambda returns a Lambda client
+func NewLambda(cfg *aws.Config) *Lambda {
+	baseURL := fmt.Sprintf(fmtExtensionURL, os.Getenv("AWS_LAMBDA_RUNTIME_API"))
+	l := &Lambda{
+		baseURL:    baseURL,
+		httpClient: &http.Client{},
+		pageSize:   50,
+	}
+	if cfg != nil {
+		l.lambdaClient = lambda.NewFromConfig(*cfg)
+	}
+	return l
+}
+
+type LambdaFunction struct {
+	ARN  string
+	Name string
+	Tags map[string]string
+}
+
+func (c *Lambda) GetFunction(ctx context.Context, arn string) (LambdaFunction, error) {
+	fn, err := c.lambdaClient.GetFunction(ctx, &lambda.GetFunctionInput{
+		FunctionName: &arn,
+	})
+	if err != nil {
+		return LambdaFunction{}, err
+	}
+
+	return LambdaFunction{
+		ARN:  *fn.Configuration.FunctionArn,
+		Name: *fn.Configuration.FunctionName,
+		Tags: fn.Tags,
+	}, nil
+}
+
+// ListFunctions returns a map of LambdaMeta indexed by ARN.
+func (c *Lambda) ListFunctions(ctx context.Context) (map[string]LambdaFunction, error) {
+	var resultErr error
+	params := &lambda.ListFunctionsInput{MaxItems: aws.Int32(int32(c.pageSize))}
+	paginator := lambda.NewListFunctionsPaginator(c.lambdaClient, params)
+	lambdas := make(map[string]LambdaFunction)
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			resultErr = multierror.Append(resultErr, err)
+			return nil, resultErr
+		}
+
+		// TODO: fetch Lambda functions concurrently
+		for _, l := range output.Functions {
+			fn, err := c.GetFunction(ctx, *l.FunctionArn)
+			if err != nil {
+				resultErr = multierror.Append(resultErr, err)
+				continue
+			}
+
+			lambdas[fn.ARN] = fn
+		}
+	}
+
+	return lambdas, nil
+}
+
+// ProcessEvents polls the Lambda Extension API for events. Currently all this
+// does is signal readiness to the Lambda platform after each event, which is
+// required in the Extension API.
+// The first call to NextEvent signals completion of the extension
+// init phase.
+func (c *Lambda) ProcessEvents(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			res, err := c.next(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to receive next event: %w", err)
+			}
+			// Exit if we receive a SHUTDOWN event
+			if res.EventType == Shutdown {
+				return nil
+			}
+		}
+	}
+}
+
+// Register the named extension with the Lambda Extensions API
+// The interface value i is the name of the extension to register as a string.
+// If i is not a string a non-nil error is returned.
+func (c *Lambda) Register(ctx context.Context, i interface{}) error {
+	const action = "/register"
+	url := c.baseURL + action
+
+	name, ok := i.(string)
+	if !ok {
+		return fmt.Errorf("invalid input type, expected string")
+	}
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"events": []EventType{Shutdown},
+	})
+	if err != nil {
+		return err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set(headerExtensionName, name)
+	httpRes, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	if httpRes.StatusCode != 200 {
+		return fmt.Errorf("extension registration request failed with status %s", httpRes.Status)
+	}
+	c.extensionID = httpRes.Header.Get(headerExtensionID)
+	return nil
+}
+
+// next blocks while long polling for the next lambda invoke or shutdown
+func (c *Lambda) next(ctx context.Context) (*NextEventResponse, error) {
+	const action = "/event/next"
+	url := c.baseURL + action
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set(headerExtensionID, c.extensionID)
+	httpRes, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if httpRes.StatusCode != 200 {
+		return nil, fmt.Errorf("request failed with status %s", httpRes.Status)
+	}
+	defer httpRes.Body.Close()
+	body, err := ioutil.ReadAll(httpRes.Body)
+	if err != nil {
+		return nil, err
+	}
+	res := NextEventResponse{}
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/consul-lambda-registrator/client/ssm.go
+++ b/consul-lambda-registrator/client/ssm.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// SSMClient provides an API client for interacting with AWS Systems Manager Parameter Store.
+type SSMClient struct {
+	client *ssm.Client
+}
+
+// NewSSM creates an instance of the SSMClient from the given AWS SDK config.
+func NewSSM(cfg *aws.Config) *SSMClient {
+	return &SSMClient{client: ssm.NewFromConfig(*cfg)}
+}
+
+// Delete removes the value for the given key from Parameter Store.
+func (c *SSMClient) Delete(ctx context.Context, key string) error {
+	_, err := c.client.DeleteParameter(ctx, &ssm.DeleteParameterInput{Name: &key})
+	return err
+}
+
+// Get retrieves the value for the given key from Parameter Store.
+// Get assumes that the value is encrypted as a SecureString and returns the decrypted value.
+func (c *SSMClient) Get(ctx context.Context, key string) (string, error) {
+	paramValue, err := c.client.GetParameter(
+		ctx,
+		&ssm.GetParameterInput{
+			Name:           &key,
+			WithDecryption: true,
+		})
+
+	if err != nil {
+		return "", err
+	}
+
+	val := paramValue.Parameter.Value
+	if val == nil {
+		return "", fmt.Errorf("parameter store value does not exist for %s", key)
+	}
+	return *val, nil
+}
+
+// Set writes the value for the given key to Parameter Store.
+// It writes the value as an encrypted SecureString.
+// Any existing data for the given key is overwritten.
+func (c *SSMClient) Set(ctx context.Context, key, val string) error {
+	_, err := c.client.PutParameter(
+		ctx,
+		&ssm.PutParameterInput{
+			Name:      &key,
+			Value:     &val,
+			Overwrite: true,
+			Type:      types.ParameterTypeSecureString,
+		},
+	)
+	return err
+}

--- a/consul-lambda-registrator/consul-lambda-extension/main.go
+++ b/consul-lambda-registrator/consul-lambda-extension/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/hashicorp/go-hclog"
+	"github.com/kelseyhightower/envconfig"
+
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/client"
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/extension"
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/trace"
+)
+
+const (
+	defaultLogLevel = "info"
+	extensionName   = "consul-lambda-extension"
+)
+
+func main() {
+	trace.Enabled(strings.ToLower(getEnvOrDefault("TRACE_ENABLED", "false")) == "true")
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.LevelFromString(getEnvOrDefault("LOG_LEVEL", defaultLogLevel)),
+	})
+
+	err := realMain(logger.Named(extensionName))
+	if err != nil {
+		logger.Error("fatal error, exiting", "error", err)
+		os.Exit(1)
+	}
+}
+
+func realMain(logger hclog.Logger) error {
+	trace.Enter()
+	defer trace.Exit()
+
+	trace.SetLogger(trace.HCLog{Logger: logger})
+
+	cfg, err := configure()
+	if err != nil {
+		return err
+	}
+
+	cfg.Logger = logger
+	ext := extension.NewExtension(cfg)
+
+	// Handle interrupts and shutdown notification
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdownChannel := make(chan struct{})
+	go func() {
+		interruptChannel := make(chan os.Signal, 1)
+		signal.Notify(interruptChannel, syscall.SIGTERM, syscall.SIGINT)
+
+		select {
+		case s := <-interruptChannel:
+			logger.Info("Received signal, exiting", "signal", s)
+		case <-shutdownChannel:
+			logger.Info("Received shutdown event, exiting")
+		}
+		// Cancel our context so that all servers and go-routines exit gracefully.
+		cancel()
+	}()
+
+	err = ext.Serve(ctx)
+	if err != nil {
+		logger.Error("processing failed with an error", "error", err)
+	}
+
+	// Once processEvents returns, signal that it's time to shutdown.
+	shutdownChannel <- struct{}{}
+
+	return err
+}
+
+func configure() (*extension.Config, error) {
+	trace.Enter()
+	defer trace.Exit()
+
+	// Load the configuration from the environment.
+	cfg := &extension.Config{}
+	err := envconfig.Process("consul", cfg)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to load configuration from environment: %w", err)
+	}
+
+	if cfg.ServiceName == "" {
+		// If the service name wasn't explicitly configured then default to the Lambda function's name.
+		cfg.ServiceName = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+	}
+
+	sdkConfig, err := config.LoadDefaultConfig(context.Background(), config.WithRetryer(func() aws.Retryer {
+		// Adaptive mode should retry on hitting rate limits.
+		return retry.AddWithMaxBackoffDelay(retry.NewAdaptiveMode(), 3*time.Second)
+	}))
+	if err != nil {
+		return cfg, fmt.Errorf("failed to create AWS SDK configuration: %w", err)
+	}
+
+	ssmClient := client.NewSSM(&sdkConfig)
+
+	lambdaClient := client.NewLambda(&sdkConfig)
+	err = lambdaClient.Register(context.Background(), extensionName)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to register Lambda extension: %w", err)
+	}
+
+	cfg.Events = lambdaClient
+	cfg.Store = ssmClient
+	return cfg, nil
+}
+
+func getEnvOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}

--- a/consul-lambda-registrator/extension/extension.go
+++ b/consul-lambda-registrator/extension/extension.go
@@ -1,0 +1,252 @@
+package extension
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/proxy"
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/structs"
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/trace"
+)
+
+type Config struct {
+	MeshGatewayURI      string        `envconfig:"MESH_GATEWAY_URI" required:"true"`
+	ExtensionDataPrefix string        `envconfig:"EXTENSION_DATA_PREFIX" required:"true"`
+	Datacenter          string        `envconfig:"DATACENTER"`
+	ServiceName         string        `envconfig:"SERVICE_NAME"`
+	ServiceNamespace    string        `envconfig:"SERVICE_NAMESPACE"`
+	ServicePartition    string        `envconfig:"SERVICE_PARTITION"`
+	ServiceUpstreams    []string      `envconfig:"SERVICE_UPSTREAMS"`
+	RefreshFrequency    time.Duration `envconfig:"REFRESH_FREQUENCY" default:"5m"`
+	Timeout             time.Duration `envconfig:"PROXY_TIMEOUT" default:"10s"`
+	LogLevel            string        `envconfig:"LOG_LEVEL" default:"info"`
+	TraceEnabled        bool          `envconfig:"TRACE_ENABLED" default:"false"`
+
+	Store  ParamGetter
+	Events EventProcessor
+	Logger hclog.Logger
+}
+
+type ParamGetter interface {
+	// Get the value for the given key.
+	Get(ctx context.Context, key string) (string, error)
+}
+
+type EventProcessor interface {
+	// Register the event processor.
+	Register(ctx context.Context, i interface{}) error
+	// ProcessEvents handles events until the provided context is cancelled or an error occurs.
+	ProcessEvents(ctx context.Context) error
+}
+
+type Extension struct {
+	*Config
+	service structs.Service
+	proxy   *proxy.Server
+}
+
+func NewExtension(cfg *Config) *Extension {
+
+	ext := &Extension{
+		Config: cfg,
+		service: structs.Service{
+			Datacenter: cfg.Datacenter,
+			Name:       cfg.ServiceName,
+			Namespace:  cfg.ServiceNamespace,
+			Partition:  cfg.ServicePartition,
+		},
+	}
+
+	return ext
+}
+
+func (ext *Extension) Serve(ctx context.Context) error {
+	trace.Enter()
+	defer trace.Exit()
+
+	// Initialize the proxy server.
+	err := ext.initProxy(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Start the proxy
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		err := ext.proxy.Serve()
+		if err != nil {
+			ext.Logger.Error("proxy failed with an error", "error", err)
+		}
+		// Once the proxy exits we cannot handle any more events so cancel our context.
+		cancel()
+	}()
+	defer ext.proxy.Close()
+
+	// Start the event processor and block until it returns.
+	// It will return when there are no more events to process or its context is cancelled,
+	// whichever happens first.
+	ext.Logger.Info("processing events")
+	err = ext.Events.ProcessEvents(ctx)
+	if err != nil {
+		return fmt.Errorf("event processing failed with an error: %w", err)
+	}
+
+	ext.Logger.Info("processing events finished")
+	return nil
+}
+
+func (ext *Extension) getExtensionData(ctx context.Context) (structs.ExtensionData, error) {
+	trace.Enter()
+	defer trace.Exit()
+
+	var extData structs.ExtensionData
+
+	// Retrieve the data.
+	key := fmt.Sprintf("%s%s", ext.ExtensionDataPrefix, ext.service.ExtensionPath())
+	d, err := ext.Store.Get(ctx, key)
+	if err != nil {
+		return extData, fmt.Errorf("failed to get extension data for %s: %w", key, err)
+	}
+
+	// Unmarshal.
+	if err := json.Unmarshal([]byte(d), &extData); err != nil {
+		return extData, fmt.Errorf("failed to unmarshal extension data for %s: %w", key, err)
+	}
+	return extData, nil
+}
+
+func (ext *Extension) initProxy(ctx context.Context) error {
+	trace.Enter()
+	defer trace.Exit()
+
+	// Get the lambda extension configuration data for this service.
+	extData, err := ext.getExtensionData(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to init proxy: %w", err)
+	}
+
+	// Parse the configured list of upstreams.
+	upstreams, err := ext.parseUpstreams(extData)
+	if err != nil {
+		return fmt.Errorf("failed to init proxy: %w", err)
+	}
+
+	// Create a proxy listener configuration for each upstream.
+	proxyConfigs := make([]*proxy.Config, len(upstreams))
+	for i, upstream := range upstreams {
+		// Create the listener config.
+		cfg, err := ext.proxyConfig(upstream, extData)
+		if err != nil {
+			return fmt.Errorf("failed to init proxy: %w", err)
+		}
+		proxyConfigs[i] = cfg
+	}
+
+	// Create the proxy server.
+	ext.proxy = proxy.New(proxyConfigs...)
+
+	return nil
+}
+
+func (ext *Extension) proxyConfig(upstream structs.Service, extData structs.ExtensionData) (*proxy.Config, error) {
+	trace.Enter()
+	defer trace.Exit()
+
+	cfg := &proxy.Config{}
+
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM([]byte(extData.RootCertPEM))
+
+	cert, err := tls.X509KeyPair([]byte(extData.CertPEM), []byte(extData.PrivateKeyPEM))
+	if err != nil {
+		return cfg, err
+	}
+
+	// Listen on the upstream's port on all interfaces.
+	cfg.ListenFunc = func() (net.Listener, error) {
+		return net.Listen("tcp", fmt.Sprintf(":%d", upstream.Port))
+	}
+
+	// TODO: How do we want to handle cert rotation?
+	// Considerations:
+	// - Lambda rgy will keep the mTLS material up-to-date in parameter store.
+	// - The extension will likely live between invocations and the mTLS material may go stale
+	// - We shouldn't ever need to recreate the ListenerFunc because it isn't TLS
+	// - We could recreate the DialFunc with updated mTLS on every request.. but that may be overkill?
+	// - Could keep a record (hash) of the mTLS material and update DialFunc only if it has changed.
+	// - In either case, I think this means that the proxy must support updating the DialFunc in flight.
+	//
+	// De-registration is another case to consider:
+	// - When a Lambda service is de-registered we want it to no longer be able to call into the mesh.
+	// - Lambda registrator deletes the mTLS data from parameter store.
+	// - If the Lambda RT and extension stays alive - this is realistic, I've seen it stay up for >15m -
+	//   then the DialFunc for each upstream still contains the mTLS info needed to call in to the mesh (not good).
+
+	// Wrap the outgoing request in an mTLS session and dial the mesh gateway.
+	cfg.DialFunc = func() (net.Conn, error) {
+		return tls.Dial("tcp", ext.MeshGatewayURI, &tls.Config{
+			RootCAs:            roots,
+			Certificates:       []tls.Certificate{cert},
+			ServerName:         upstream.SNI(),
+			InsecureSkipVerify: true,
+			VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+				certs := make([]*x509.Certificate, len(rawCerts))
+				for i, asn1Data := range rawCerts {
+					cert, err := x509.ParseCertificate(asn1Data)
+					if err != nil {
+						return fmt.Errorf("failed to parse tls certificate from peer: %w", err)
+					}
+					certs[i] = cert
+				}
+
+				opts := x509.VerifyOptions{
+					Roots:         roots,
+					Intermediates: x509.NewCertPool(),
+				}
+
+				// All but the first cert are intermediates.
+				for _, cert := range certs[1:] {
+					opts.Intermediates.AddCert(cert)
+				}
+
+				_, err := certs[0].Verify(opts)
+				if err != nil {
+					return err
+				}
+
+				// Match the SPIFFE ID.
+				if !strings.EqualFold(certs[0].URIs[0].String(), upstream.SpiffeID()) {
+					return errors.New("spiffe id mismatch")
+				}
+				return nil
+			},
+		})
+	}
+
+	return cfg, nil
+}
+
+func (ext *Extension) parseUpstreams(extData structs.ExtensionData) ([]structs.Service, error) {
+	trace.Enter()
+	defer trace.Exit()
+
+	u := make([]structs.Service, 0, len(ext.ServiceUpstreams))
+	for _, s := range ext.ServiceUpstreams {
+		up, err := structs.ParseService(s)
+		if err != nil {
+			return u, fmt.Errorf("failed to parse upstream: %w", err)
+		}
+		up.TrustDomain = extData.TrustDomain
+		u = append(u, up)
+	}
+	return u, nil
+}

--- a/consul-lambda-registrator/extension/extension_test.go
+++ b/consul-lambda-registrator/extension/extension_test.go
@@ -1,0 +1,54 @@
+package extension_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	ext "github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/extension"
+)
+
+func TestExtension(t *testing.T) {
+	cfg := &ext.Config{
+		MeshGatewayURI:      "mesh.gateway.consul:8443",
+		ExtensionDataPrefix: "test",
+		ServiceName:         "lambda-function",
+		ServiceUpstreams:    []string{"upstream-1:1234", "upstream-2:1235"},
+		Store:               MockParamGetter{},
+		Events:              MockEventProcessor{},
+		Logger:              hclog.Default(),
+	}
+
+	e := ext.NewExtension(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go e.Serve(ctx)
+
+	time.Sleep(time.Second)
+	cancel()
+	time.Sleep(time.Second)
+}
+
+type MockParamGetter struct{}
+
+func (m MockParamGetter) Get(_ context.Context, _ string) (string, error) {
+	return extensionData, nil
+}
+
+type MockEventProcessor struct{}
+
+func (m MockEventProcessor) Register(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (m MockEventProcessor) ProcessEvents(ctx context.Context) error {
+	fmt.Println("MOCK PROCESSING EVENTS")
+	<-ctx.Done()
+	fmt.Println("MOCK PROCESSING COMPLETED")
+	return nil
+}
+
+const extensionData = `{"privateKey":"-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIBOESs619TDc4W+v2pT1B4HcIm5YsOpdWGcrUr8CaAxXoAoGCCqGSM49\nAwEHoUQDQgAEFIbwX0KkjD2z247PF5QDM6KV0oMtJYJvqT7tvE7aJNvcVI3UqHt9\nPVDyObnIw8ezr49WBCYAwIZsbsBWFs+kUQ==\n-----END EC PRIVATE KEY-----\n","cert":"-----BEGIN CERTIFICATE-----\nMIICJDCCAcmgAwIBAgIBDTAKBggqhkjOPQQDAjAxMS8wLQYDVQQDEyZwcmktMWgz\naXZqcXIuY29uc3VsLmNhLjFlNmRlNDM4LmNvbnN1bDAeFw0yMjA4MTUxOTExMzVa\nFw0yMjA4MTgxOTExMzVaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQUhvBf\nQqSMPbPbjs8XlAMzopXSgy0lgm+pPu28Ttok29xUjdSoe309UPI5ucjDx7Ovj1YE\nJgDAhmxuwFYWz6RRo4IBATCB/jAOBgNVHQ8BAf8EBAMCA7gwHQYDVR0lBBYwFAYI\nKwYBBQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwKQYDVR0OBCIEIJaBEXNd\nFjRFqu84YweH5HbE5i2LnRKS6jrjjKIt05QqMCsGA1UdIwQkMCKAICke+V39fWi7\ni7sSSu3z61tg5zHelIPeHo7EF/ODP6aKMGcGA1UdEQEB/wRdMFuGWXNwaWZmZTov\nLzFlNmRlNDM4LWMyYmQtZTYzMi0wY2UxLWMwZmE1ODYwN2E0NS5jb25zdWwvbnMv\nZGVmYXVsdC9kYy9kYzEvc3ZjL2xhbWJkYS1zZXJ2aWNlMAoGCCqGSM49BAMCA0kA\nMEYCIQC8jGhSMn3H9ME9tamBwwOLH1l78S0AjaJN9plQgLdtOwIhANVnYkOaBQdK\n4GoRF96mtwqJ2X0fosLYBG2pUKgDuw0l\n-----END CERTIFICATE-----\n","rootCert":"-----BEGIN CERTIFICATE-----\nMIICEDCCAbWgAwIBAgIBBzAKBggqhkjOPQQDAjAxMS8wLQYDVQQDEyZwcmktMWgz\naXZqcXIuY29uc3VsLmNhLjFlNmRlNDM4LmNvbnN1bDAeFw0yMjA4MTUxNDQyNTZa\nFw0zMjA4MTIxNDQyNTZaMDExLzAtBgNVBAMTJnByaS0xaDNpdmpxci5jb25zdWwu\nY2EuMWU2ZGU0MzguY29uc3VsMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPg8b\n92nHCFRObrt/A2ZlyIpDa7pfUJsMkeom04RqFiLDta9sgPx63qTBwyRLAvmCmBoC\nD9nUAJ0lHVN4jlRC9aOBvTCBujAOBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUw\nAwEB/zApBgNVHQ4EIgQgKR75Xf19aLuLuxJK7fPrW2DnMd6Ug94ejsQX84M/poow\nKwYDVR0jBCQwIoAgKR75Xf19aLuLuxJK7fPrW2DnMd6Ug94ejsQX84M/poowPwYD\nVR0RBDgwNoY0c3BpZmZlOi8vMWU2ZGU0MzgtYzJiZC1lNjMyLTBjZTEtYzBmYTU4\nNjA3YTQ1LmNvbnN1bDAKBggqhkjOPQQDAgNJADBGAiEA3QMknYjieerzcpMZhPXA\n/nI/HVoTnh/E95WdVDwcMYgCIQDjdESSjPoikuRaN5IMZoZwO6/aHmI/WH3I7xFS\nqS3Zjw==\n-----END CERTIFICATE-----\n","trustDomain":"1e6de438-c2bd-e632-0ce1-c0fa58607a45.consul"}`

--- a/consul-lambda-registrator/go.mod
+++ b/consul-lambda-registrator/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.27.0
+	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.9.0
 	github.com/hashicorp/go-hclog v0.12.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.7.1
 )

--- a/consul-lambda-registrator/go.sum
+++ b/consul-lambda-registrator/go.sum
@@ -81,6 +81,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/consul-lambda-registrator/structs/ext_data.go
+++ b/consul-lambda-registrator/structs/ext_data.go
@@ -1,0 +1,23 @@
+package structs
+
+// ExtensionData holds the information that a Lambda function needs to call services in the Consul service mesh.
+type ExtensionData struct {
+	// PrivateKeyPEM is the TLS certificate private key in PEM format.
+	PrivateKeyPEM string `json:"privateKeyPEM"`
+	// CertPEM is the TLS certificate in PEM format.
+	CertPEM string `json:"certPEM"`
+	// RootCertPEM is the TLS root CA certificate in PEM format.
+	RootCertPEM string `json:"rootCertPEM"`
+	// TrustDomain is the trusted domain that the service belongs to.
+	TrustDomain string `json:"trustDomain"`
+	// Peers is the list of peers.
+	Peers []Peer `json:"peers,omitempty"`
+}
+
+// Peer holds the information for a Consul peer.
+type Peer struct {
+	// Name of the peer.
+	Name string `json:"name"`
+	// TrustDomain is the trusted domain of the peer.
+	TrustDomain string `json:"trustDomain"`
+}

--- a/consul-lambda-registrator/structs/service.go
+++ b/consul-lambda-registrator/structs/service.go
@@ -1,0 +1,131 @@
+package structs
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	internal        = "internal"
+	version         = "v1"
+	internalVersion = internal + "-" + version
+)
+
+type Service struct {
+	Name        string
+	Port        int
+	Namespace   string
+	Partition   string
+	Datacenter  string
+	TrustDomain string
+	Subset      string
+}
+
+// ParseService parses a string in unlabeled upstream format into a Service instance.
+func ParseService(s string) (Service, error) {
+	var upstream Service
+	var err error
+
+	// Split on ":" to extract the name components, port and optional datacenter
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 {
+		return upstream, fmt.Errorf("invalid service format: %s", s)
+	}
+
+	// Get the port
+	if upstream.Port, err = strconv.Atoi(parts[1]); err != nil {
+		return upstream, fmt.Errorf("invalid service port: %w", err)
+	}
+
+	// Split the first part on "." to get the qualified component parts
+	qname := strings.Split(parts[0], ".")
+	upstream.Name = qname[0]
+	if len(qname) > 1 {
+		upstream.Namespace = qname[1]
+	}
+	if len(qname) > 2 {
+		upstream.Partition = qname[2]
+	}
+
+	// Optional datacenter
+	if len(parts) > 2 {
+		upstream.Datacenter = parts[2]
+	}
+
+	return upstream, nil
+}
+
+func (u Service) SNI() string {
+	ns := u.NamespaceOrDefault()
+	ap := u.PartitionOrDefault()
+	dc := u.DatacenterOrDefault()
+
+	switch ap {
+	case "default":
+		if u.Subset == "" {
+			return dotJoin(u.Name, ns, dc, internal, u.TrustDomain)
+		} else {
+			return dotJoin(u.Subset, u.Name, ns, dc, internal, u.TrustDomain)
+		}
+	default:
+		if u.Subset == "" {
+			return dotJoin(u.Name, ns, ap, dc, internalVersion, u.TrustDomain)
+		} else {
+			return dotJoin(u.Subset, u.Name, ns, ap, dc, internalVersion, u.TrustDomain)
+		}
+	}
+}
+
+func (u Service) DatacenterOrDefault() string {
+	if u.Datacenter == "" {
+		return "dc1"
+	}
+	return u.Datacenter
+}
+
+func (u Service) NamespaceOrDefault() string {
+	if u.Namespace == "" {
+		return "default"
+	}
+	return u.Namespace
+}
+
+func (u Service) PartitionOrDefault() string {
+	if u.Partition == "" {
+		return "default"
+	}
+	return u.Partition
+}
+
+func (u Service) SpiffeID() string {
+	path := fmt.Sprintf("/ns/%s/dc/%s/svc/%s",
+		u.NamespaceOrDefault(),
+		u.DatacenterOrDefault(),
+		u.Name,
+	)
+
+	// Although OSS has no support for partitions, it still needs to be able to
+	// handle exportedPartition from peered Consul Enterprise clusters in order
+	// to generate the correct SpiffeID.
+	// We intentionally avoid using pbpartition.DefaultName here to be OSS friendly.
+	if ap := u.PartitionOrDefault(); ap != "" && ap != "default" {
+		path = "/ap/" + ap + path
+	}
+
+	id := &url.URL{
+		Scheme: "spiffe",
+		Host:   u.TrustDomain,
+		Path:   path,
+	}
+	return id.String()
+}
+
+func (u Service) ExtensionPath() string {
+	return fmt.Sprintf("/%s/%s/%s", u.PartitionOrDefault(), u.NamespaceOrDefault(), u.Name)
+}
+
+func dotJoin(parts ...string) string {
+	return strings.Join(parts, ".")
+}

--- a/consul-lambda-registrator/structs/service_test.go
+++ b/consul-lambda-registrator/structs/service_test.go
@@ -1,0 +1,94 @@
+package structs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/structs"
+)
+
+const (
+	svc  = "test-service"
+	port = 1234
+	ns   = "ns1"
+	ap   = "ap1"
+	dc   = "dc2"
+	td   = "ba471007-78d1-3261-2e02-24258f2cb341.consul"
+
+	internal        = "internal"
+	version         = "v1"
+	internalVersion = internal + "-" + version
+)
+
+func TestService(t *testing.T) {
+
+	cases := map[string]struct {
+		str  string
+		up   structs.Service
+		sni  string
+		sid  string
+		path string
+		err  string
+	}{
+		"service only": {
+			up:   structs.Service{TrustDomain: td, Name: svc, Port: port},
+			str:  fmt.Sprintf("%s:%d", svc, port),
+			sni:  fmt.Sprintf("%s.default.dc1.%s.%s", svc, internal, td),
+			sid:  fmt.Sprintf("spiffe://%s/ns/default/dc/dc1/svc/%s", td, svc),
+			path: fmt.Sprintf("/default/default/%s", svc),
+		},
+		"service, ns": {
+			up:   structs.Service{TrustDomain: td, Name: svc, Port: port, Namespace: ns},
+			str:  fmt.Sprintf("%s.%s:%d", svc, ns, port),
+			sni:  fmt.Sprintf("%s.%s.dc1.%s.%s", svc, ns, internal, td),
+			sid:  fmt.Sprintf("spiffe://%s/ns/%s/dc/dc1/svc/%s", td, ns, svc),
+			path: fmt.Sprintf("/default/%s/%s", ns, svc),
+		},
+		"service, ns, ap": {
+			up:   structs.Service{TrustDomain: td, Name: svc, Port: port, Namespace: ns, Partition: ap},
+			str:  fmt.Sprintf("%s.%s.%s:%d", svc, ns, ap, port),
+			sni:  fmt.Sprintf("%s.%s.%s.dc1.%s.%s", svc, ns, ap, internalVersion, td),
+			sid:  fmt.Sprintf("spiffe://%s/ap/%s/ns/%s/dc/dc1/svc/%s", td, ap, ns, svc),
+			path: fmt.Sprintf("/%s/%s/%s", ap, ns, svc),
+		},
+		"service, ns, ap, dc": {
+			up:   structs.Service{TrustDomain: td, Name: svc, Port: port, Namespace: ns, Partition: ap, Datacenter: dc},
+			str:  fmt.Sprintf("%s.%s.%s:%d:%s", svc, ns, ap, port, dc),
+			sni:  fmt.Sprintf("%s.%s.%s.%s.%s.%s", svc, ns, ap, dc, internalVersion, td),
+			sid:  fmt.Sprintf("spiffe://%s/ap/%s/ns/%s/dc/%s/svc/%s", td, ap, ns, dc, svc),
+			path: fmt.Sprintf("/%s/%s/%s", ap, ns, svc),
+		},
+		"invalid service format": {
+			up:  structs.Service{},
+			str: svc,
+			err: "invalid service format",
+		},
+		"invalid port": {
+			up:  structs.Service{},
+			str: "invalid:port",
+			err: "invalid service port",
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			c := c
+			t.Parallel()
+			obs, err := structs.ParseService(c.str)
+			obs.TrustDomain = td
+			if len(c.err) == 0 {
+				require.NoError(t, err)
+				require.True(t, cmp.Equal(c.up, obs), cmp.Diff(c.up, obs))
+				require.Equal(t, c.sni, obs.SNI())
+				require.Equal(t, c.sid, obs.SpiffeID())
+				require.Equal(t, c.path, obs.ExtensionPath())
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.err)
+			}
+		})
+	}
+}

--- a/consul-lambda-registrator/trace/logger.go
+++ b/consul-lambda-registrator/trace/logger.go
@@ -1,0 +1,36 @@
+package trace
+
+import (
+	"fmt"
+	"log"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+// StdLog is a Logger that uses the stdlib log package to output timer information.
+type StdLog struct{}
+
+// Print writes timer information using log.Print.
+func (l StdLog) Print(args ...interface{}) {
+	log.Print(fmt.Sprint(args...))
+}
+
+// HCLog is a Logger that uses the go-hclog log package to output timer information.
+type HCLog struct {
+	// Logger is the Logger to use to write the timer information.
+	Logger hclog.Logger
+	// Level is the log level at which to output the timer data.
+	// The default level is Info if a level is not provided.
+	Level hclog.Level
+}
+
+// Print writes timer information using the logger's Log function, with the configured level.
+func (l HCLog) Print(args ...interface{}) {
+	if l.Logger == nil {
+		return
+	}
+	if l.Level == hclog.NoLevel {
+		l.Level = hclog.Info
+	}
+	l.Logger.Log(l.Level, fmt.Sprint(args...))
+}

--- a/consul-lambda-registrator/trace/trace.go
+++ b/consul-lambda-registrator/trace/trace.go
@@ -1,0 +1,161 @@
+// Package trace provides simple interfaces for timing applications
+package trace
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+type Logger interface {
+	Print(args ...interface{})
+}
+
+var (
+	// enabled controls whether or not tracing is enabled globally. By default it is disabled
+	// and all API calls simply return without performing any processing to minimize any
+	// performance impact from this package.
+	enabled bool = false
+	// logger is the logger to use to when logging messages.
+	// By default timers will use the log package from the stdlib to log messages.
+	logger Logger = StdLog{}
+	// tag is prepended to every trace log message.
+	tag = "trace"
+
+	traceMap = make(map[string]*Timer)
+	mu       sync.Mutex
+)
+
+func Enabled(e bool) {
+	if e == enabled {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	enabled = e
+
+	// Purge any existing timers
+	for k := range traceMap {
+		delete(traceMap, k)
+	}
+}
+
+func IsEnabled() bool {
+	return enabled
+}
+
+func Enter() {
+	if !enabled {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Get calling function
+	fname := getCaller()
+	if fname == "" {
+		return
+	}
+
+	// Create a timer and add it to the map
+	// TODO: support multiple timers with the same name
+	if _, exists := traceMap[fname]; exists {
+		return
+	}
+	traceMap[fname] = Start(fname)
+}
+
+func Exit() {
+	if !enabled {
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Get calling function
+	fname := getCaller()
+	if fname == "" {
+		return
+	}
+
+	// Get the timer, log the time and remove it from the map
+	// TODO: support multiple timers with the same name
+	timer, exists := traceMap[fname]
+	if !exists {
+		return
+	}
+	timer.Since()
+	delete(traceMap, fname)
+}
+
+func GetLogger() Logger {
+	mu.Lock()
+	defer mu.Unlock()
+	return logger
+}
+
+func SetLogger(l Logger) {
+	mu.Lock()
+	defer mu.Unlock()
+	logger = l
+}
+
+func GetTag() string {
+	mu.Lock()
+	defer mu.Unlock()
+	return tag
+}
+
+func SetTag(t string) {
+	mu.Lock()
+	defer mu.Unlock()
+	tag = t
+}
+
+type Timer struct {
+	Tag  string
+	Log  Logger
+	name string
+	t0   time.Time
+}
+
+// Start a timer with the specified name.
+func Start(name string) *Timer {
+	return &Timer{Tag: tag, Log: logger, name: name, t0: time.Now()}
+}
+
+// Since logs the time since the timer started. If present the optional args will be appended to the message.
+func (t *Timer) Since(args ...interface{}) {
+	if t.Log == nil {
+		t.Log = StdLog{}
+	}
+	var msg []interface{}
+	if tag != "" {
+		msg = []interface{}{tag, " ", t.name, ": ", time.Since(t.t0)}
+	} else {
+		msg = []interface{}{t.name, ": ", time.Since(t.t0)}
+	}
+	if len(args) > 0 {
+		msg = append(msg, " ")
+		msg = append(msg, args...)
+	}
+	t.Log.Print(msg...)
+}
+
+func getCaller() string {
+	pc := make([]uintptr, 10)
+	n := runtime.Callers(3, pc)
+	if n == 0 {
+		return ""
+	}
+	pc = pc[:n]
+	frames := runtime.CallersFrames(pc)
+	if frames == nil {
+		return ""
+	}
+	frame, _ := frames.Next()
+	return frame.Function
+}

--- a/consul-lambda-registrator/trace/trace_test.go
+++ b/consul-lambda-registrator/trace/trace_test.go
@@ -1,0 +1,58 @@
+package trace_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-aws-consul-lambda-registrator/consul-lambda-registrator/trace"
+)
+
+func TestTraceStdLog(t *testing.T) {
+	trace.Enabled(false)
+	require.False(t, trace.IsEnabled())
+	trace.Enabled(true)
+	require.True(t, trace.IsEnabled())
+	trace.SetTag("trace")
+	Func1()
+	Func2()
+	Both()
+	trace.SetTag("")
+	Func1()
+}
+
+func TestTraceHCLog(t *testing.T) {
+	trace.Enabled(false)
+	require.False(t, trace.IsEnabled())
+	trace.Enabled(true)
+	require.True(t, trace.IsEnabled())
+	trace.SetLogger(trace.HCLog{Logger: hclog.Default()})
+	trace.SetTag("trace")
+
+	Func1()
+	Func2()
+	Both()
+	trace.SetTag("")
+	Func1()
+}
+
+func Func1() {
+	trace.Enter()
+	time.Sleep(time.Millisecond)
+	trace.Exit()
+}
+
+func Func2() {
+	trace.Enter()
+	time.Sleep(time.Millisecond)
+	trace.Exit()
+}
+
+func Both() {
+	trace.Enter()
+	Func1()
+	Func2()
+	trace.Exit()
+}


### PR DESCRIPTION
## Changes proposed in this PR:
This PR adds the `consul-lambda-extension` implementation that proxies service mesh requests between Lambda functions and Consul mesh gateways.

The implementation in `consul-lambda-extension/main.go` was modelled after the implementation from [`vault-lambda-extension`](https://github.com/hashicorp/vault-lambda-extension/blob/main/main.go). The files in the `client/`, `extension/`, `structs/` and `trace/` directory are new and are specific to supporting the Consul-Lambda integration use case.

## How I've tested this PR:
- Unit tests (incomplete)
- Sandbox environment with Consul, mesh services and a mesh gateway running on ECS and Lambda functions calling into the mesh through this proxy implementation.

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::